### PR TITLE
Maptastik/issue5

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3,7 +3,7 @@ html, body {
     margin: 0;
     height: 100%;
     width: 100%;
-    font-family: "Avenir Next W00";
+    font-family: "Staatliches", sans-serif;
 }
 
 .sidebar {

--- a/css/style.css
+++ b/css/style.css
@@ -8,7 +8,7 @@ html, body {
 
 .sidebar {
     grid-area: sidebar;
-    background-color: #333;
+    background-color: #F9EFE6;
 }
 
 .map {
@@ -24,7 +24,7 @@ html, body {
 }
 
 .box {
-    color: #fff;
+    color: #121212;
     padding: 10px;
     font-size: 20px;
 }

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 
     <!-- JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chroma-js/2.1.2/chroma.min.js" integrity="sha512-8TVPS0EFkkmtT6yPb5K4csnSt3tjbKRrs0F8gvTNKv2OxOcwDO7+Klkz86gMVrzfqtZos5N2a+k+r9D+hlccmQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.slim.min.js" integrity="sha256-u7e5khyithlIdTpu22PHhENmPcRdFiHRjhAuHcs05RI=" crossorigin="anonymous"></script>
 
 </head>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A==" crossorigin="" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-+0n0xVW2eSR5OomGNYDnhzAbDsOXxcvSN1TPprVMTNDbiYZCxYbOOl7+AMvyTG2x" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Staatliches&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="./css/style.css"></link>
 
     <!-- JS -->

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,14 @@
 // -----------------------------------
 // --------- GLOBAL VARIABLES --------
 let year = 2020,
-    indicator = 'li';
+    indicator = 'li',
+    colorScales = {
+        reds: chroma.scale('reds').colors(8),
+        oranges: chroma.scale('oranges').colors(8),
+        blues: chroma.scale('blues').colors(8),
+        greens: chroma.scale('greens').colors(8),
+        purples: chroma.scale('purples').colors(8)
+    };
 // -----------------------------------
 // -----------------------------------
 
@@ -26,7 +33,7 @@ async function fetchJSON(url) {
 
 function style(feature) {
     return {
-        fillColor: getColor(feature.properties[`${indicator}${year}`]),
+        fillColor: getColor(feature.properties[`${indicator}${year}`], colorScales.purples),
         weight: 2,
         opacity: 1,
         color: 'white',
@@ -34,13 +41,13 @@ function style(feature) {
     };
 }
 
-function getColor(d) {
-    return d > .9 ? '#800026' :
-           d > .8  ? '#BD0026' :
-           d > .7  ? '#E31A1C' :
-           d > .6  ? '#FC4E2A' :
-           d > .5   ? '#FD8D3C' :
-           d > .4   ? '#FEB24C' :
-           d > .3   ? '#FED976' :
-                      '#FFEDA0';
+function getColor(d, colorScale) {
+    return d > .9 ? colorScale[7] :
+           d > .8 ? colorScale[6] :
+           d > .7 ? colorScale[5] :
+           d > .6 ? colorScale[4] :
+           d > .5 ? colorScale[3] :
+           d > .4 ? colorScale[2] :
+           d > .3 ? colorScale[1] :
+                    colorScale[0];
 }


### PR DESCRIPTION
This addresses the basic front-end styling setup needs from #5.

- Adds Staatliches font family as primary font for the page
- Changes the sidebar from gray to a sandy tan
- Adds sequential, single-hue color scales from ColorBrewer

On this last point, I incorporated a third-party library, chroma-js, to handle generating the arrays containing the color values for each color scale. I think this will offer some convenience as it allows us to more easily alter the number of classes in our color scales while still using the same base color scheme from Color Brewer. For example, the following two variables are equivalent values:

```javascript
let reds8HardCoded = ["#fff5f0", "#fedbcb", "#fcaf94", "#fc8161", "#f44f39", "#d52221", "#aa1016", "#67000d"]
let reds8ChromaJS = chroma.scale('reds').colors(8)
```

The benefit is more apparent when you want to change the number of classes. For example, if we only wanted 5 instead of 8:
```javascript
let reds5HardCoded = ['#fee5d9','#fcae91','#fb6a4a','#de2d26','#a50f15']
let reds5ChromaJS = chroma.scale('reds').colors(5)
```

Beyond flexibility, I contend that accessing the ColorBrewer scales via Chroma-JS is easier to read than an array of hex-codes. What do you all think?
